### PR TITLE
Add an exit command to strip_symbols.sh

### DIFF
--- a/breakpad_tools/windows/strip_symbols.sh
+++ b/breakpad_tools/windows/strip_symbols.sh
@@ -19,3 +19,5 @@ mv $symbol_file ../symbols/"$binary_name.pdb"/$uuid/
 chmod +x $BIN_PATH/windows/sentry-cli.exe 
 
 $BIN_PATH/windows/sentry-cli --auth-token 00985397724343d496af4d0f88dd8c79adc5f7a5433b4ed9881b9535d0bc5eb4 upload-dif -t breakpad --project el-maven-logging --org el-maven ../symbols/
+
+exit 0


### PR DESCRIPTION
Executing strip_symbols.sh from external environments (bash emulators, PowerShell, etc.) expect the script to return or at least exit with a code to be able to resume shell session. An `exit 0` has been added to the end of the file to ensure this behavior.