### PR TITLE
Send tagged builds to update repository

### DIFF
--- a/config/config.xml
+++ b/config/config.xml
@@ -9,4 +9,11 @@
     <ControlScript>control_script.qs</ControlScript>
     <WizardStyle>Modern</WizardStyle>
     <TargetDir>@ApplicationsDir@/El-MAVEN</TargetDir>
+    <RemoteRepositories>
+        <Repository>
+            <Url>https://localhost/repository</Url>
+            <Enabled>1</Enabled>
+            <DisplayName>El-MAVEN Updates</DisplayName>
+        </Repository>
+    </RemoteRepositories>
 </Installer>

--- a/config/config.xml
+++ b/config/config.xml
@@ -1,9 +1,9 @@
 <Installer>
     <Name>El-MAVEN</Name>
-    <Version>0.2.4</Version>
+    <Version>x.y.z</Version>
     <Title>El-MAVEN Installer</Title>
     <Publisher>ElucidataInc</Publisher>
-    <ProductUrl>https://elucidatainc.github.io/ElMaven/</ProductUrl>
+    <ProductUrl>https://resources.elucidata.io/elmaven</ProductUrl>
     <InstallerApplicationIcon>maven</InstallerApplicationIcon>
     <InstallerWindowIcon>window.png</InstallerWindowIcon>
     <ControlScript>control_script.qs</ControlScript>

--- a/config/control_script.qs
+++ b/config/control_script.qs
@@ -2,9 +2,9 @@ function Controller()
 {
     console.log("intializing controller")
     if(installer.isInstaller()) {
-        installer.setValue("version", "@Name@-@Version@")
+        installer.setValue("application", "@Name@")
+        installer.setValue("version", "@Version@")
     }
-
 }
 
 Controller.prototype.IntroductionPageCallback = function()

--- a/packages/com.vendor.product/meta/installerscript.qs
+++ b/packages/com.vendor.product/meta/installerscript.qs
@@ -13,7 +13,7 @@ function Component()
 Component.prototype.createOperationsForArchive = function(archive)
 {
     console.log("performing custom extract operation")
-    component.addOperation("Extract", archive, "@TargetDir@" + "/" + installer.value("version") + "/");
+    component.addOperation("Extract", archive, "@TargetDir@" + "/" + installer.value("application") + "/");
 }
 
 Component.prototype.createOperations = function()
@@ -21,19 +21,19 @@ Component.prototype.createOperations = function()
     component.createOperations();
     if(systemInfo.productType === "windows") {
         component.addOperation("CreateShortcut",
-                               "@TargetDir@" + "/" + installer.value("version") + "/bin/El-MAVEN.exe",
+                               "@TargetDir@" + "/" + installer.value("application") + "/bin/El-MAVEN.exe",
                                "@DesktopDir@/El-MAVEN.lnk",
                                "description=El-MAVEN");
         component.addElevatedOperation("GlobalConfig",
                                        "Elucidata",
-                                       installer.value("version"),
+                                       installer.value("application") + " " + installer.value("version"),
                                        "InstallDir",
                                        "@TargetDir@");
         component.addElevatedOperation("GlobalConfig",
                                        "Elucidata",
-                                       installer.value("version"),
+                                       installer.value("application") + " " + installer.value("version"),
                                        "BinaryDir",
-                                       "@TargetDir@" + "\\" + installer.value("version") + "\\bin");
+                                       "@TargetDir@" + "\\" + installer.value("application") + "\\bin");
     }
 }
 

--- a/packages/com.vendor.product/meta/package.xml
+++ b/packages/com.vendor.product/meta/package.xml
@@ -1,8 +1,8 @@
 <Package>
-    <DisplayName>El-Maven 0.2.4</DisplayName>
-    <Description>Install El-Maven 0.2.4</Description>
-    <Version>0.2.4</Version>
-    <ReleaseDate>2018-01-25</ReleaseDate>
+    <DisplayName>El-MAVEN</DisplayName>
+    <Description>Install El-MAVEN x.y.z</Description>
+    <Version>x.y.z</Version>
+    <ReleaseDate>2020-01-01</ReleaseDate>
     <Licenses>
         <License file="license.txt" name="GPL Version 2" />
     </Licenses>

--- a/update_version.py
+++ b/update_version.py
@@ -14,7 +14,7 @@ tree = ET.parse("packages/com.vendor.product/meta/package.xml")
 root = tree.getroot()
 now = datetime.now()
 root.find("ReleaseDate").text = "{}-{:02d}-{:02d}".format(now.year, now.month, now.day)
-root.find("DisplayName").text = "El-MAVEN " +  version
+root.find("DisplayName").text = "El-MAVEN"
 root.find("Description").text = "Install El-MAVEN " +  version
 root.find("Version").text = version
 tree.write("packages/com.vendor.product/meta/package.xml")

--- a/update_version.py
+++ b/update_version.py
@@ -5,7 +5,9 @@ from datetime import datetime
 tree = ET.parse("config/config.xml")
 root = tree.getroot()
 version = sys.argv[1]
+update_branch = sys.argv[2]
 root.find("Version").text = version
+root.find("RemoteRepositories").find("Repository").find("Url").text = "https://bitbucket.org/saifulbeekhan/elmaven-updates/raw/{}".format(update_branch)
 tree.write("config/config.xml")
 
 tree = ET.parse("packages/com.vendor.product/meta/package.xml")

--- a/update_version.py
+++ b/update_version.py
@@ -5,9 +5,9 @@ from datetime import datetime
 tree = ET.parse("config/config.xml")
 root = tree.getroot()
 version = sys.argv[1]
-update_branch = sys.argv[2]
+update_repo_url = sys.argv[2]
 root.find("Version").text = version
-root.find("RemoteRepositories").find("Repository").find("Url").text = "https://elmaven-installers.s3-us-west-2.amazonaws.com/{}-updates".format(update_branch)
+root.find("RemoteRepositories").find("Repository").find("Url").text = update_repo_url
 tree.write("config/config.xml")
 
 tree = ET.parse("packages/com.vendor.product/meta/package.xml")

--- a/update_version.py
+++ b/update_version.py
@@ -7,7 +7,7 @@ root = tree.getroot()
 version = sys.argv[1]
 update_branch = sys.argv[2]
 root.find("Version").text = version
-root.find("RemoteRepositories").find("Repository").find("Url").text = "https://bitbucket.org/saifulbeekhan/elmaven-updates/raw/{}".format(update_branch)
+root.find("RemoteRepositories").find("Repository").find("Url").text = "https://elmaven-installers.s3-us-west-2.amazonaws.com/{}-updates".format(update_branch)
 tree.write("config/config.xml")
 
 tree = ET.parse("packages/com.vendor.product/meta/package.xml")

--- a/update_version.py
+++ b/update_version.py
@@ -1,23 +1,18 @@
 import xml.etree.ElementTree as ET
 import sys
-
+from datetime import datetime
 
 tree = ET.parse("config/config.xml")
 root = tree.getroot()
-
 version = sys.argv[1]
-
-
 root.find("Version").text = version
-
 tree.write("config/config.xml")
-
 
 tree = ET.parse("packages/com.vendor.product/meta/package.xml")
 root = tree.getroot()
-
-root.find("DisplayName").text = "El-Maven " +  version
-root.find("Description").text = "Install El-Maven " +  version
+now = datetime.now()
+root.find("ReleaseDate").text = "{}-{:02d}-{:02d}".format(now.year, now.month, now.day)
+root.find("DisplayName").text = "El-MAVEN " +  version
+root.find("Description").text = "Install El-MAVEN " +  version
 root.find("Version").text = version
-
 tree.write("packages/com.vendor.product/meta/package.xml")


### PR DESCRIPTION
The changes made in this PR, are mostly around:
1. Making some minor changes to configuration files (update application name, labels shown during the installer, release date , etc.)
2. Adding "update repositories" as required by the Qt Installer Framework to be able to allow users to update their existing installations when new releases are available.